### PR TITLE
Pin bcrypt to a version compatible with passlib runtime expectations …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ pytest
 gunicorn>=20.1.0
 structlog>=23.0.0
 alembic>=1.11.0
+
+# Pin bcrypt to a version compatible with passlib runtime expectations
+bcrypt==3.2.0


### PR DESCRIPTION
…in requirements.txt